### PR TITLE
refactor: Simplify AI provider to use Gemini only

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.59.0",
         "@google/generative-ai": "^0.24.1",
         "cors": "^2.8.5",
         "docx": "^9.5.1",
@@ -20,19 +19,9 @@
         "mongoose": "^8.17.1",
         "multer": "^2.0.2",
         "node-fetch": "^2.7.0",
-        "openai": "^5.12.2",
         "pdf-lib": "^1.17.1",
         "pdf-parse": "^1.1.1",
         "xlsx": "^0.18.5"
-      }
-    },
-    "node_modules/@anthropic-ai/sdk": {
-      "version": "0.59.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.59.0.tgz",
-      "integrity": "sha512-m9w9tC+N+GUNprwEOhU3VKKSYwXA1fIevRCe7kOFonV4xu5vxqmqyoLy+dkdVvc5W1F4WUTVE/7I4criaF9gnw==",
-      "license": "MIT",
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
       }
     },
     "node_modules/@google/generative-ai": {
@@ -1194,27 +1183,6 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
-      }
-    },
-    "node_modules/openai": {
-      "version": "5.12.2",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-5.12.2.tgz",
-      "integrity": "sha512-xqzHHQch5Tws5PcKR2xsZGX9xtch+JQFz5zb14dGqlshmmDAFBFEWmeIpf7wVqWV+w7Emj7jRgkNJakyKE0tYQ==",
-      "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.23.8"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
       }
     },
     "node_modules/option": {

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,6 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.59.0",
     "@google/generative-ai": "^0.24.1",
     "cors": "^2.8.5",
     "docx": "^9.5.1",
@@ -21,7 +20,6 @@
     "mongoose": "^8.17.1",
     "multer": "^2.0.2",
     "node-fetch": "^2.7.0",
-    "openai": "^5.12.2",
     "pdf-lib": "^1.17.1",
     "pdf-parse": "^1.1.1",
     "xlsx": "^0.18.5"


### PR DESCRIPTION
This commit refactors the backend AI processing service to exclusively use the Gemini API, as you requested. The integrations for OpenAI and Anthropic have been removed to simplify the codebase and align with your current requirements.

- **`server/services/aiProcessor.js`:**
  - Removed the client initializations and specific formatting functions for OpenAI and Anthropic.
  - Simplified the `parseAndFormatCV` orchestrator function to remove the multi-provider fallback logic, now directly calling the Gemini formatting function.

- **`server/package.json` & `server/package-lock.json`:**
  - Removed the `openai` and `@anthropic-ai/sdk` packages from the dependencies.
  - The `package-lock.json` file has been updated accordingly after running `npm install`.